### PR TITLE
Fixed AD Graph API deprecation issue in Azure CLI 2.37.0 and removed unnecessary dependsOn in Bicep template

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ jobs:
     - name: 'Set Service Principal ID'
       id: setSpId
       run: |
-        SP_ID=$(az ad sp show --id ${{ fromJSON(secrets.AZURE_CREDENTIALS).clientId }} --query objectId -o tsv)
+        SP_ID=$(az ad sp show --id ${{ fromJSON(secrets.AZURE_CREDENTIALS).clientId }} --query id -o tsv)
         echo "::set-output name=spId::${SP_ID}"
 
     - name: 'Mask Service Principal Key'

--- a/infrastructure/startup-stack.bicep
+++ b/infrastructure/startup-stack.bicep
@@ -204,9 +204,6 @@ resource assetsContainer 'Microsoft.Storage/storageAccounts/blobServices/contain
     denyEncryptionScopeOverride: false
     publicAccess: 'Blob'
   }
-  dependsOn: [
-    storageAccount
-  ]
 }
 
 resource filesContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2021-04-01' = {
@@ -217,9 +214,6 @@ resource filesContainer 'Microsoft.Storage/storageAccounts/blobServices/containe
     denyEncryptionScopeOverride: false
     publicAccess: 'Blob'
   }
-  dependsOn: [
-    storageAccount
-  ]
 }
 
 resource storageContributorRoleDefinition 'Microsoft.Authorization/roleDefinitions@2018-01-01-preview' existing = {
@@ -260,7 +254,6 @@ resource db 'Microsoft.DBForPostgreSql/flexibleServers@2020-02-14-preview' = {
   }
   dependsOn: [
     dbSubnet
-    dbPrivateDnsZone
     virtualNetworkLink
   ]
 }
@@ -359,7 +352,6 @@ resource webApp 'Microsoft.Web/sites@2020-06-01' = {
     }
   }
   dependsOn: [
-    appServicePlan
     containerRegistry
     webAppSubnet
   ]
@@ -377,9 +369,6 @@ resource webAppAcrRoleAssignment 'Microsoft.Authorization/roleAssignments@2020-0
     principalType: 'ServicePrincipal'
   }
   scope: containerRegistry
-  dependsOn: [
-    webApp
-  ]
 }
 
 resource webAppNetworkConfig 'Microsoft.Web/sites/networkConfig@2020-12-01' = {
@@ -464,9 +453,6 @@ resource appCdnEndpoint 'Microsoft.Cdn/profiles/endpoints@2020-09-01' = {
     queryStringCachingBehavior: 'IgnoreQueryString'
     urlSigningKeys: []
   }
-  dependsOn: [
-    webApp
-  ]
 }
 
 resource asset_endpoint 'Microsoft.Cdn/profiles/endpoints@2020-09-01' = {
@@ -503,9 +489,6 @@ resource asset_endpoint 'Microsoft.Cdn/profiles/endpoints@2020-09-01' = {
     queryStringCachingBehavior: 'IgnoreQueryString'
     urlSigningKeys: []
   }
-  dependsOn: [
-    storageAccount
-  ]
 }
 
 resource webAppCustomDomain 'Microsoft.Cdn/profiles/endpoints/customdomains@2020-09-01' = if (!empty(domain)) {
@@ -514,9 +497,6 @@ resource webAppCustomDomain 'Microsoft.Cdn/profiles/endpoints/customdomains@2020
   properties: {
     hostName: domain
   }
-  dependsOn: [
-    cdnProfile
-  ]
 }
 
 output url string = 'https://${appCdnEndpoint.properties.hostName}'


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Fixed an issue in **az ad sp** command because of AD Graph API deprecation in Azure CLI 2.37.0
* Removed unnecessary **dependsOn** in Bicep template

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Run the workflow manually from the Actions tab. By default it uses the GitHub-hosted runner with the latest Azure CLI version i.e. 2.37.0.


## What to Check
Verify that the following are valid
* The config, build and deploy stages are completed successfully
* The SP ID is successfully being populated in config job

## Other Information
<!-- Add any other helpful information that may be needed here. -->

Reference: [Microsoft Graph Migration](https://docs.microsoft.com/en-us/cli/azure/microsoft-graph-migration)